### PR TITLE
Add support for external keyboard

### DIFF
--- a/Pod/Classes/MRGPagerTitleStrip.m
+++ b/Pod/Classes/MRGPagerTitleStrip.m
@@ -253,7 +253,7 @@
             return i;
         }
     }
-    return NSNotFound; // Return NSNotFound if no button is focused
+    return NSNotFound;
 }
 
 #pragma mark - get/set

--- a/Pod/Classes/MRGPagerTitleStrip.m
+++ b/Pod/Classes/MRGPagerTitleStrip.m
@@ -173,7 +173,7 @@
     
     BOOL animatedScroll = NO;
     CGFloat indexToScrollTo = self.currentIndex;
-    NSInteger focusedButtonIndex = [self findIndexOfFocusedButton];
+    NSInteger focusedButtonIndex = [self indexOfFocusedButton];
     if (focusedButtonIndex != NSNotFound) {
         indexToScrollTo = focusedButtonIndex;
         animatedScroll = YES;
@@ -246,14 +246,16 @@
     }];
 }
 
-- (NSInteger)findIndexOfFocusedButton {
-    for (NSInteger i = 0; i < [self.buttons count]; i++) {
-        UIButton *button = self.buttons[i];
+- (NSInteger)indexOfFocusedButton {
+    __block NSInteger focusedIndex = NSNotFound;
+    [self.buttons enumerateObjectsUsingBlock:^(UIButton *button, NSUInteger idx, BOOL *stop) {
         if (button.isFocused) {
-            return i;
+            focusedIndex = idx;
+            *stop = YES;
         }
-    }
-    return NSNotFound;
+    }];
+    
+    return focusedIndex;
 }
 
 #pragma mark - get/set

--- a/Pod/Classes/MRGPagerTitleStrip.m
+++ b/Pod/Classes/MRGPagerTitleStrip.m
@@ -170,7 +170,16 @@
     self.scrollView.contentSize = CGSizeMake(((buttonLeft > 0.0f) ? (buttonLeft + separatorSize.width) : 0.0f), size.height);
     
     [self.scrollView layoutIfNeeded];
-    [self scrollToIndex:self.currentIndex animated:NO];
+    
+    BOOL animatedScroll = NO;
+    CGFloat indexToScrollTo = self.currentIndex;
+    NSInteger focusedButtonIndex = [self findIndexOfFocusedButton];
+    if (focusedButtonIndex != NSNotFound) {
+        indexToScrollTo = focusedButtonIndex;
+        animatedScroll = YES;
+    }
+    
+    [self scrollToIndex:indexToScrollTo animated:animatedScroll];
     
     [self.delegate pagerStripSizeChanged:self];
 }
@@ -223,10 +232,10 @@
         offset -= ((CGRectGetWidth(self.scrollView.bounds) - width) * 0.5f);
         
         offset = MIN(MAX(offset, 0), self.scrollView.contentSize.width - CGRectGetWidth(self.scrollView.bounds));
-        [self.scrollView setContentOffset:CGPointMake(offset, self.scrollView.contentOffset.y) animated:NO];
+        [self.scrollView setContentOffset:CGPointMake(offset, self.scrollView.contentOffset.y) animated:animated];
         
     } else {
-        [self.scrollView setContentOffset:CGPointMake(0, self.scrollView.contentOffset.y) animated:NO];
+        [self.scrollView setContentOffset:CGPointMake(0, self.scrollView.contentOffset.y) animated:animated];
     }
 }
 
@@ -235,6 +244,16 @@
     [self.buttons enumerateObjectsUsingBlock:^(UIButton *button, NSUInteger buttonIndex, BOOL *stop) {
         [button setSelected:(buttonIndex == currentIndex)];
     }];
+}
+
+- (NSInteger)findIndexOfFocusedButton {
+    for (NSInteger i = 0; i < [self.buttons count]; i++) {
+        UIButton *button = self.buttons[i];
+        if (button.isFocused) {
+            return i;
+        }
+    }
+    return NSNotFound; // Return NSNotFound if no button is focused
 }
 
 #pragma mark - get/set


### PR DESCRIPTION
## Description
iOS now has a feature called "Full Keyboard access" to supports navigation using an external keyboard since iOS 13.

This component wasn't fully operable using an external keyboard:

- When moving the keyboard focus on hidden tabs (tabs outside the visible portion of the app), the content wasn't scrolling, because it was always scrolled back automatically to the selected tab.

We now make sure that the focused tab is visible when the focus is on one of the tabs. And when the focus leaves the tabs, the scroll view is scrolled back to the selected tab:


https://github.com/mirego/MRGPagerController/assets/25367344/d04c40e2-104d-47e1-a72b-4282064c424d

## Note
- In the video, we see that the focus will be brought back to the last focused tab when the focus comes back to the control instead of going back to the selected tab. This could be improved in another PR.