### PR TITLE
Accessibility: Fix the support of external keyboard when using arrow.

### DIFF
--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -153,7 +153,7 @@
 
 - (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {
     [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
-}
+    [self moveToPageIndex: MAX(self.pagerStrip.currentIndex - 1, 0)];
 
 - (void)moveToPageIndex:(NSUInteger)index {
     if (index != self.pagerStrip.currentIndex) {

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -124,7 +124,7 @@
     // Only when an external keyboard is connected
     // The default (Drag gesture) of UIScrollView is disabled;
     // and need to be replaced with swipe gesture
-    [self addGestureRecogniser]; //
+    [self addGestureRecogniser];
 }
 
 - (void)hardwareKeyboardDidDisonnect:(NSNotification *)notification {

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -27,6 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #import "MRGPagerController.h"
+#import "GameController/GCKeyboard.h"
 
 @interface MRGPagerController ()<UIScrollViewDelegate, MRGPagerStripDelegate>
 
@@ -37,6 +38,8 @@
 @property (nonatomic) BOOL callDidEndScrollingOnNextViewDidLayoutSubviews;
 @property (nonatomic) CGSize lastSize;
 @property (nonatomic, weak, nullable) UIViewController *lastViewControllerEndedScrollingOn;
+@property (nonatomic) UISwipeGestureRecognizer *swipeLeft;
+@property (nonatomic) UISwipeGestureRecognizer *swipeRight;
 @end
 
 @implementation MRGPagerController
@@ -63,6 +66,7 @@
     _pagerStrip.delegate = nil;
     _pagerScrollView.delegate = nil;
     _delegate = nil;
+    [self removeKeyboardObserver];
 }
 
 #pragma mark - lifecyle
@@ -84,9 +88,80 @@
     self.pagerScrollView.pagingEnabled = YES;
     self.pagerScrollView.showsHorizontalScrollIndicator = NO;
     self.pagerScrollView.showsVerticalScrollIndicator = NO;
+    
+    // Need to support external keyboard for Accessibility
+    // and fix the conflict between keyboard arrow <-> and UIScrollView behavior
+    // NOTE1: Don't work to detect keyboard with [GCKeyboard coalescedKeyboard] because it always nil
+    // NOTE2: I don't find a correct solution to access app.isFullKeyboardAccessEnabledé
+    [self addKeyboardObserver];
+    
     [self.view addSubview:self.pagerScrollView];
     
     [self updateViewControllersWithOldViewControllers:nil newViewControllers:self.viewControllers animated:NO];
+}
+
+#pragma mark - Support external keyboard for Accessibility
+
+- (void)addKeyboardObserver {
+    if (@available(iOS 14.0, *)) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hardwareKeyboardDidConnect:) name:GCKeyboardDidConnectNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hardwareKeyboardDidDisonnect:) name:GCKeyboardDidDisconnectNotification object:nil];
+    }
+}
+
+- (void)removeKeyboardObserver {
+    if (@available(iOS 14.0, *)) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:GCKeyboardDidConnectNotification object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:GCKeyboardDidDisconnectNotification object:nil];
+    }
+}
+
+- (void)hardwareKeyboardDidConnect:(NSNotification *)notification {
+    
+    // Fix the conflict between keyboard arrow <-> and UIScrollView behavior
+    self.pagerScrollView.scrollEnabled = NO;
+    
+    // Only when an external keyboard is connected
+    // The default (Drag gesture) of UIScrollView is disabled;
+    // and need to be replaced with swipe gesture
+    [self addGestureRecogniser]; //
+}
+
+- (void)hardwareKeyboardDidDisonnect:(NSNotification *)notification {
+    self.pagerScrollView.scrollEnabled = YES;
+    [self removeGestureRecogniser];
+}
+
+- (void)addGestureRecogniser {
+    self.swipeLeft = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeLeft:)];
+    [self.swipeLeft setDirection:(UISwipeGestureRecognizerDirectionLeft)];
+    [self.pagerScrollView addGestureRecognizer:self.swipeLeft];
+    
+    self.swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeRight:)];
+    [self.swipeRight setDirection:(UISwipeGestureRecognizerDirectionRight)];
+    [self.pagerScrollView addGestureRecognizer:self.swipeRight];
+}
+
+- (void)removeGestureRecogniser {
+    [self.pagerScrollView removeGestureRecognizer:self.swipeLeft];
+    [self.pagerScrollView removeGestureRecognizer:self.swipeRight];
+}
+
+- (void)handleSwipeLeft:(UISwipeGestureRecognizer *)recognizer
+{
+    [self moveToPageIndex: MIN(self.pagerStrip.currentIndex +1, self.viewControllers.count -1)];
+}
+
+- (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer
+{
+    [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
+}
+
+- (void)moveToPageIndex:(NSUInteger)index {
+    if (index != self.pagerStrip.currentIndex) {
+        [self.pagerStrip setCurrentIndex:index animated:YES];
+        [self setCurrentViewController:self.viewControllers[index] animated:YES];
+    }
 }
 
 #pragma mark - layout

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -151,8 +151,7 @@
     [self moveToPageIndex: MIN(self.pagerStrip.currentIndex +1, self.viewControllers.count -1)];
 }
 
-- (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer
-{
+- (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {
     [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
 }
 

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -122,8 +122,8 @@
     self.pagerScrollView.scrollEnabled = NO;
     
     // Only when an external keyboard is connected
-    // The default (Drag gesture) of UIScrollView is disabled;
-    // and need to be replaced with swipe gesture
+    // The default (Drag gesture) of UIScrollView is disabled
+    // and needs to be replaced with a swipe gesture
     [self addGestureRecogniser];
 }
 

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -148,7 +148,7 @@
 }
 
 - (void)handleSwipeLeft:(UISwipeGestureRecognizer *)recognizer {
-    [self moveToPageIndex: MIN(self.pagerStrip.currentIndex +1, self.viewControllers.count -1)];
+    [self moveToPageIndex: MIN(self.pagerStrip.currentIndex + 1, self.viewControllers.count - 1)];
 }
 
 - (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -148,7 +148,7 @@
 }
 
 - (void)handleSwipeLeft:(UISwipeGestureRecognizer *)recognizer {
-    [self moveToPageIndex: MIN(self.pagerStrip.currentIndex + 1, self.viewControllers.count - 1)];
+    [self moveToPageIndex: MIN(self.pagerStrip.currentIndex +1, self.viewControllers.count -1)];
 }
 
 - (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -154,6 +154,7 @@
 - (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {
     [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
     [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
+}
 
 - (void)moveToPageIndex:(NSUInteger)index {
     if (index != self.pagerStrip.currentIndex) {

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -147,8 +147,7 @@
     [self.pagerScrollView removeGestureRecognizer:self.swipeRight];
 }
 
-- (void)handleSwipeLeft:(UISwipeGestureRecognizer *)recognizer
-{
+- (void)handleSwipeLeft:(UISwipeGestureRecognizer *)recognizer {
     [self moveToPageIndex: MIN(self.pagerStrip.currentIndex +1, self.viewControllers.count -1)];
 }
 

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -89,10 +89,10 @@
     self.pagerScrollView.showsHorizontalScrollIndicator = NO;
     self.pagerScrollView.showsVerticalScrollIndicator = NO;
     
-    // Need to support external keyboard for Accessibility
+    // Need to support external keyboard for accessibility
     // and fix the conflict between keyboard arrow <-> and UIScrollView behavior
-    // NOTE1: Don't work to detect keyboard with [GCKeyboard coalescedKeyboard] because it always nil
-    // NOTE2: I don't find a correct solution to access app.isFullKeyboardAccessEnabledé
+    // NOTE 1: Using [GCKeyboard coalescedKeyboard] to detect the keyboard doesn't work because it always returns nil
+    // NOTE 2: Haven't found a proper solution to access app.isFullKeyboardAccessEnabled
     [self addKeyboardObserver];
     
     [self.view addSubview:self.pagerScrollView];

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -153,7 +153,7 @@
 
 - (void)handleSwipeRight:(UISwipeGestureRecognizer *)recognizer {
     [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
-    [self moveToPageIndex: MAX(self.pagerStrip.currentIndex - 1, 0)];
+    [self moveToPageIndex: MAX(self.pagerStrip.currentIndex -1, 0)];
 
 - (void)moveToPageIndex:(NSUInteger)index {
     if (index != self.pagerStrip.currentIndex) {


### PR DESCRIPTION
## Description and motivation

Notre MRGPagerController ne supporte pas bien les claviers externes.
L'utilisation des flèches (Gauche droite) du clavier cause des problèmes important de comportement puisque ces dernières  sont interceptés par le scrollview principale du composant.

### Tasks

- [x] Correction du support pour les claviers externes pour l'accessibilité
- [x] Ajout de swift gesture pour remplacer la perte du drag lorsqu'un clavier est present.



