### PR TITLE
Automatically resize the views when Dynamic Content size changes

### DIFF
--- a/Example/MRGPagerController/MRGDemoTabStrip.m
+++ b/Example/MRGPagerController/MRGDemoTabStrip.m
@@ -40,7 +40,7 @@
     if (self) {
         self.backgroundColor = [UIColor grayColor];
         self.titleTextAlignment = NSTextAlignmentCenter;
-        self.titleFont = [UIFont italicSystemFontOfSize:24];
+        self.titleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
         self.titleTextColor = [UIColor blueColor];
         self.titleHighlightedTextColor = [[UIColor redColor] colorWithAlphaComponent:0.5];
         self.titleTextSpacing = 30.0f;
@@ -53,7 +53,17 @@
         self.tabIndicatorColor = [UIColor yellowColor];
     }
 
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(contentSizeChanged) name:UIContentSizeCategoryDidChangeNotification object:nil];
+    
     return self;
+}
+
+- (void)dealloc {
+    [NSNotificationCenter.defaultCenter removeObserver:self name:UIContentSizeCategoryDidChangeNotification object:nil];
+}
+
+- (void)contentSizeChanged {
+    self.titleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
 }
 
 @end

--- a/Pod/Classes/MRGPagerController.m
+++ b/Pod/Classes/MRGPagerController.m
@@ -476,6 +476,7 @@
 #pragma mark - MRGPagerStripDelegate
 
 - (void)pagerStripSizeChanged:(id<MRGPagerStrip>)pagerStrip {
+    self.lastSize = CGSizeZero;
     [self.view setNeedsLayout];
 }
 


### PR DESCRIPTION
Fonts in the tabs, and tab size were not automatically resized when the user changes the desired font size in the iOS settings.

To resize the text automatically, reload and set the UIFont as demonstrated in `MRGDemoTabStrip.m`

The change in MRGPagerController.m is to make the tabs resize automatically when the font size changes: when calling pagerStripSizeChanged, reset the last saved size to make sure the tabs are resized when layout is reloaded.